### PR TITLE
Debug toolbar update and add panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.X.1 ()
+- Dev dependencies updates (debug toolbar)
+
 # 1.4.0 (2020-05-14)
 - Add a page listing processes for a given source
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ django-debug-toolbar = "==2.2"
 factory-boy = "*"
 tzlocal = "*"
 coverage = "*"
-debug-toolbar-user-panel = {editable = true,git = "https://github.com/Napoleon-Black/django-debug-toolbar-user-panel.git"}
+debug-toolbar-user-panel = {editable = true,git = "https://github.com/Napoleon-Black/django-debug-toolbar-user-panel.git", ref="1481b04e0cbbf7db35bf43061883535ef25892f5"}
 ipython = "*"
 django-debug-toolbar-request-history = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,12 +5,13 @@ verify_ssl = true
 
 [dev-packages]
 black = "==19.3b0"
-django-debug-toolbar = "==1.7"
+django-debug-toolbar = "==2.2"
 factory-boy = "*"
 tzlocal = "*"
 coverage = "*"
-debug-toolbar-user-panel = {editable = true,git = "https://github.com/bport/django-debug-toolbar-user-panel.git"}
+debug-toolbar-user-panel = {editable = true,git = "https://github.com/Napoleon-Black/django-debug-toolbar-user-panel.git"}
 ipython = "*"
+django-debug-toolbar-request-history = "*"
 
 [packages]
 django-bootstrap-static = ">=3.3.7,<3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "075c320c718b0676bcbdcd623aadc9b4a98f501e9471c8dee1f30ca7b9ebff8d"
+            "sha256": "ed6d4e1a89fe09d5c46b42ae94b84df2af3550e1e090f88687a25b762a9d9364"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -150,10 +150,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "pyparsing": {
             "hashes": [
@@ -220,6 +220,14 @@
                 "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
             ],
             "version": "==1.4.4"
+        },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
         },
         "asgiref": {
             "hashes": [
@@ -296,8 +304,8 @@
         },
         "debug-toolbar-user-panel": {
             "editable": true,
-            "git": "https://github.com/bport/django-debug-toolbar-user-panel.git",
-            "ref": "b41a9bd4f83060623f3a6880420598fc8b50cae4"
+            "git": "https://github.com/Napoleon-Black/django-debug-toolbar-user-panel.git",
+            "ref": "1481b04e0cbbf7db35bf43061883535ef25892f5"
         },
         "decorator": {
             "hashes": [
@@ -316,11 +324,19 @@
         },
         "django-debug-toolbar": {
             "hashes": [
-                "sha256:89831c775d5317d47825c03426a04404a9042e23385039fbc14549ace8781107",
-                "sha256:bd929113ae22d7553c3ae6a6cb6762e8453784972eca06fa396aca47d0b66874"
+                "sha256:eabbefe89881bbe4ca7c980ff102e3c35c8e8ad6eb725041f538988f2f39a943",
+                "sha256:ff94725e7aae74b133d0599b9bf89bd4eb8f5d2c964106e61d11750228c8774c"
             ],
             "index": "pypi",
-            "version": "==1.7"
+            "version": "==2.2"
+        },
+        "django-debug-toolbar-request-history": {
+            "hashes": [
+                "sha256:79013b50ba59d93d998b6f168ca4325eb5be3a9b859d48fb14aae80819f3a734",
+                "sha256:b4e53f1da523d6fe7d2a9cb1b0cf4ce7c83c8a02fad56555ec041911371e62cd"
+            ],
+            "index": "pypi",
+            "version": "==0.1.1"
         },
         "factory-boy": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed6d4e1a89fe09d5c46b42ae94b84df2af3550e1e090f88687a25b762a9d9364"
+            "sha256": "40c9522c10c194d80619a6810efc041226c60a6c7f7023af22215bc4df7aa0c9"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -186,10 +186,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "sqlparse": {
             "hashes": [
@@ -434,10 +434,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "sqlparse": {
             "hashes": [

--- a/pyoupyou/settings/dev.py
+++ b/pyoupyou/settings/dev.py
@@ -15,6 +15,7 @@ INSTALLED_APPS += ["debug_toolbar", "debug_toolbar_user_panel"]
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
 DEBUG_TOOLBAR_PANELS = [
+    "ddt_request_history.panels.request_history.RequestHistoryPanel",
     "debug_toolbar_user_panel.panels.UserPanel",
     "debug_toolbar.panels.versions.VersionsPanel",
     "debug_toolbar.panels.timer.TimerPanel",

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,12 @@ django==2.2.12
 future==0.18.2
 icalendar==4.0.6
 idna==2.9
-packaging==20.3
+packaging==20.4
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2020.1
 requests==2.23.0
-six==1.14.0
+six==1.15.0
 sqlparse==0.3.1
 urllib3==1.25.9
 webencodings==0.5.1


### PR DESCRIPTION
- Bump django-debug-toolbar to 2.2
- Use a fork of debug-toolbar-user-panel compatible with DBT ≥ 2.0
- Install django-debug-toolbar-request-history