### PR TITLE
Simplify candidate creation process

### DIFF
--- a/interview/forms.py
+++ b/interview/forms.py
@@ -82,6 +82,20 @@ class OfferForm(forms.ModelForm):
     helper.form_tag = False
 
 
+class InterviewersForm(forms.ModelForm):
+    class Meta:
+        model = Interview
+        fields = ["interviewers"]
+        widgets = {"interviewers": MultipleConsultantWidget}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["interviewers"].required = False
+
+    helper = FormHelper()
+    helper.form_tag = False
+
+
 class InterviewForm(forms.ModelForm):
     class Meta:
         model = Interview

--- a/interview/templates/interview/new_candidate.html
+++ b/interview/templates/interview/new_candidate.html
@@ -32,6 +32,9 @@
     <form method="post" class="relative" enctype="multipart/form-data">
         {% crispy candidate_form %}
         {% crispy process_form %}
+        {% if interviewers_form %}
+        {% crispy interviewers_form %}
+        {% endif %}
         <input type="submit" name="summit" value="{% trans "Save" %}" class="btn btn-primary btn-primary" id="submit-id-summit">
     </form>
     <div id="create-source" class="modal fade" tabindex="-1" role="dialog">

--- a/interview/views.py
+++ b/interview/views.py
@@ -48,6 +48,7 @@ from interview.forms import (
     CloseForm,
     UploadSeekubeFileForm,
     OfferForm,
+    InterviewersForm,
 )
 from interview.models import Process, Document, Interview, Sources, SourcesCategory, Candidate, Offer
 from ref.models import Consultant, PyouPyouUser, Subsidiary
@@ -279,6 +280,7 @@ def new_candidate(request):
     else:
         candidate_form = ProcessCandidateForm()
         process_form = ProcessForm()
+        interviewers_form = InterviewersForm(prefix="interviewers")
     source_form = SourceForm(prefix="source")
     offer_form = OfferForm(prefix="offer")
     return render(
@@ -289,6 +291,7 @@ def new_candidate(request):
             "process_form": process_form,
             "source_form": source_form,
             "offer_form": offer_form,
+            "interviewers_form": interviewers_form,
         },
     )
 

--- a/interview/views.py
+++ b/interview/views.py
@@ -268,7 +268,8 @@ def new_candidate(request):
     if request.method == "POST":
         candidate_form = ProcessCandidateForm(data=request.POST, files=request.FILES)
         process_form = ProcessForm(data=request.POST)
-        if candidate_form.is_valid() and process_form.is_valid():
+        interviewers_form = InterviewersForm(prefix="interviewers", data=request.POST)
+        if candidate_form.is_valid() and process_form.is_valid() and interviewers_form.is_valid():
             candidate = candidate_form.save()
             content = request.FILES.get("cv", None)
             if content:
@@ -276,6 +277,11 @@ def new_candidate(request):
             process = process_form.save(commit=False)
             process.candidate = candidate
             process.save()
+            if interviewers_form.cleaned_data["interviewers"]:
+                interview = interviewers_form.save(commit=False)
+                interview.process = process
+                interview.save()
+                interviewers_form.save_m2m()
             return HttpResponseRedirect(reverse("process-details", args=[str(process.id)]))
     else:
         candidate_form = ProcessCandidateForm()


### PR DESCRIPTION
It is now possible to optionally enter interviewers when creating a new candidate. In that case it will also create the corresponding first interview.