### PR TITLE
Provisionning API now uses company code instead of full name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - New ICS feeds: per subsidiary and per user
 - Bugs
   - Fix source report page, show count filtered by subsidiary
+- Provisionning API now uses company code instead of full name
 
 # 1.11.4 (2021-10-19)
 - Fix activity summary page (lazy translation)

--- a/interview/views.py
+++ b/interview/views.py
@@ -542,7 +542,7 @@ def create_offer_ajax(request):
 @user_passes_test(lambda u: u.is_superuser)
 def create_account(request):
     data = json.loads(request.body)
-    subsidiary = Subsidiary.objects.filter(name=data["company"]).first()
+    subsidiary = Subsidiary.objects.filter(code=data["company"]).first()
     if not subsidiary:
         return JsonResponse({"error": "Company not found"}, status=404)
     try:


### PR DESCRIPTION
Closes #148